### PR TITLE
Use commonjs in example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -2,7 +2,7 @@
   "name": "example",
   "version": "1.0.0",
   "description": "",
-  "type": "module",
+  "type": "commonjs",
   "main": "app.js",
   "scripts": {
     "etcm": "../bin/etcm.js '**/*.{css,scss,less}'"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:tsc": "run-s -c lint:tsc:*",
     "lint:tsc:src": "tsc -p tsconfig.src.json --noEmit",
     "lint:tsc:test": "tsc -p tsconfig.test.json --noEmit",
+    "lint:tsc:example": "tsc -p tsconfig.example.json --noEmit",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules $NODE_OPTIONS\" jest"
   },
   "bin": {

--- a/tsconfig.example.json
+++ b/tsconfig.example.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["example/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    // Compatible for Node.js v12 (ref: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)
+    "target": "ES2019",
+    "lib": ["ES2019"]
+  }
+}

--- a/tsconfig.example.json
+++ b/tsconfig.example.json
@@ -3,6 +3,7 @@
   "include": ["example/**/*"],
   "exclude": ["node_modules"],
   "compilerOptions": {
+    "module": "CommonJS",
     // Compatible for Node.js v12 (ref: https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)
     "target": "ES2019",
     "lib": ["ES2019"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,9 @@
 // ref: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#support-for-solution-style-tsconfigjson-files
 {
   "files": [],
-  "references": [{ "path": "./tsconfig.src.json" }, { "path": "./tsconfig.test.json" }]
+  "references": [
+    { "path": "./tsconfig.src.json" },
+    { "path": "./tsconfig.test.json" },
+    { "path": "./tsconfig.example.json" }
+  ]
 }


### PR DESCRIPTION
There is a bug in `module: "Node16"` that prevents `tsc` from resolving `.css.d.ts` (https://github.com/microsoft/TypeScript/issues/50133). Therefore, use `module: "CommonJS"` instead of `module: "Node16"` in the example.