### PR TITLE
feat!: require Node.js `^22.20.0 || ^24.8.0 || >=26.0.0`

### DIFF
--- a/.github/workflows/ci-node.yml
+++ b/.github/workflows/ci-node.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 26
           cache: 'npm'
       - run: npm install
       - run: npm run lint
@@ -24,11 +24,11 @@ jobs:
       matrix:
         include:
           # Node.js
-          - node: '18'
-          - node: '20'
           - node: '22'
+          - node: '24'
+          - node: '26'
           # less
-          - node: '22'
+          - node: '26'
             less: '^3.0.0'
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 26
           cache: 'npm'
       - run: npm install
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "vitest": "^2.1.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "^22.20.0 || ^24.8.0 || >=26.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "mizdra",
   "license": "MIT",
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^22.20.0 || ^24.8.0 || >=26.0.0"
   },
   "packageManager": "npm@9.6.4",
   "prettier": "@mizdra/prettier-config-mizdra",


### PR DESCRIPTION
## Purpose

Node.js 18 and 20 have both reached EOL. Drop support for them and require Node.js 22 or later.

## Breaking Change

Drops support for Node.js 18 / 20. Users must upgrade to Node.js 22 or later.
