### PR TITLE
chore: migrate from Prettier to Oxfmt

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ __snapshots__/
 *.scss.d.ts
 *.less.d.ts
 /docs/how-does-definition-jumps-work
+/.claude

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint", "vitest.explorer"]
+  "recommendations": ["oxc.oxc-vscode", "dbaeumer.vscode-eslint", "vitest.explorer"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,32 @@
 {
   "editor.tabSize": 2,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "oxc.oxc-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
   "css.validate": false,
   "less.validate": false,
-  "scss.validate": false
+  "scss.validate": false,
+  "[javascript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "oxc.oxc-vscode"
+  }
 }

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,0 +1,1 @@
+export { default } from '@mizdra/oxfmt-config';

--- a/oxfmt.config.ts
+++ b/oxfmt.config.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-default-export
 export { default } from '@mizdra/oxfmt-config';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@eslint/eslintrc": "^3.0.0",
         "@eslint/js": "^8.37.0",
         "@mizdra/eslint-config-mizdra": "^2.0.0",
-        "@mizdra/prettier-config-mizdra": "^1.0.0",
+        "@mizdra/oxfmt-config": "^0.2.0",
         "@types/dedent": "^0.7.2",
         "@types/eslint": "^9.6.0",
         "@types/glob": "^8.1.0",
@@ -26,9 +26,9 @@
         "eslint": "^8.57.0",
         "less": "^4.2.0",
         "npm-run-all2": "^6.2.0",
+        "oxfmt": "^0.53.0",
         "postcss-import": "^16.1.0",
         "postcss-simple-vars": "^7.0.1",
-        "prettier": "~2.8.8",
         "sass": "^1.77.1",
         "typescript": "^5.4.5",
         "vitest": "^2.1.4"
@@ -762,18 +762,14 @@
         }
       }
     },
-    "node_modules/@mizdra/prettier-config-mizdra": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@mizdra/prettier-config-mizdra/-/prettier-config-mizdra-1.0.0.tgz",
-      "integrity": "sha512-XukmUe7FrXEGnL1efi1H6oTY/GuCcjt3oA5tblia/kYmTqJ3Ciqz/3WN57liv0TDZC2aKNMQ3f0Bxp0rUEJCXA==",
+    "node_modules/@mizdra/oxfmt-config": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mizdra/oxfmt-config/-/oxfmt-config-0.2.0.tgz",
+      "integrity": "sha512-7SlDOebqnNrhtFanij9DdvGOy3yDq+560qItT/flC56tFcAsnPgOVDId2DLwh/YH1Ds8GH9g2BuFEzEov91M8A==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "prettier": ">=2.4.0"
-      },
-      "peerDependenciesMeta": {
-        "prettier": {
-          "autoinstall": true
-        }
+        "oxfmt": ">=0.41.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -809,6 +805,353 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.53.0.tgz",
+      "integrity": "sha512-XfVM8AmIovBTKXCt14Op5wbfcoM8418nttd+nhMgM3RAVaJg1MtJc73FyWfUt0oxLyBGVwfniNVUsbV/b3VmPg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.53.0.tgz",
+      "integrity": "sha512-btHDfXckwdf9zgyAVznfZkf+GVyB0I1m1hlvaOMRx2xoyz3hphfPX97s89J3wfCN8QBETLtk4lQUaeOkrMuQOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.53.0.tgz",
+      "integrity": "sha512-k2RjMcSTkHjoOlsVGbL35JVzXL+oQco3GHPl/5kjebVF4oHNfE24In8F5isqBh9LBJucycWHKDXdGrCchdWcHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.53.0.tgz",
+      "integrity": "sha512-65jIBE2H1l5SSs16fmv6/7b6sAx/WpvnsgDhVWK9qSjNFDUro7MPQ6q5UhpY7kl46yltfR046iAnxy/Bzqbiew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.53.0.tgz",
+      "integrity": "sha512-oYe1gkz7U49PCYrS9147d2fJZj8mDI4Di6AvlsU5fu9p+Tq8S7qqOMSZjUiVTLX8bXuSA9Lk/tIxuegVjkNYRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.53.0.tgz",
+      "integrity": "sha512-ailB2vLzGi629tymdAb2VYJyEHref7oqGxP+tRBrtRBxQrb6NV55JMT7xtGZ8uTeG2+Y9zojqW4LhJYxQnz9Pg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.53.0.tgz",
+      "integrity": "sha512-abh4mWBvOvD966sobqF7r103y2yYx7Rb4WGHLOS4+5igGqLbbPxS9aK5+45D6iUY7dWMsk3Muz9a8gUtufvqJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.53.0.tgz",
+      "integrity": "sha512-z73PvuhJ8qA+cDbaiqbtopHglA91U4+y5wn2sTJJrnpB957d5P33FEuyP3DQIFd7ofljmDmfVT4G0CVGHZaJWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.53.0.tgz",
+      "integrity": "sha512-I6bhOTroqc3ThrwZ89l2k3ivKuELhdPLbAcJhRNyjWvlgwb0vjRgEnVL1XLx5Jud04/ypNRZBykAWrSk6l/D+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.53.0.tgz",
+      "integrity": "sha512-w0p3JzB/PkkQjXALMJMqP9YfP3yq4w6zGsu5kezQmUnxRkN3b/Theg2l/nDgBsOcczxS3gL6Gam5XNAVrO6QJQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.53.0.tgz",
+      "integrity": "sha512-mzBhF6k1Yq1K/dqDmVe/AAafnlJfEpx7yfUiksyeWXJk5iSzZqBSxcsa02zIytYgQFRZ7h6WPZfwHg/DoOE1Kw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.53.0.tgz",
+      "integrity": "sha512-AlFCpnRQhogQFzZXWbO6xB6/Udy745L+eQNmDPGg7G/OeWsYmJc4jZYfUN5pQg0reOPWSED2mOQqKZOJM1U8cA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.53.0.tgz",
+      "integrity": "sha512-XD4ulY4f1DWbuuZXAqxhVn+gdPmrhnmojWtFN78ctVoupmS845fGhsUrk1HZXKQI+iymbaiz9vAjPsghHNQ7Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.53.0.tgz",
+      "integrity": "sha512-xg8KWX0QnxmYWRe60CgHYWXI0ZOtBbqTsXvWiWrcl2XUHJ3fht2QerOk2iWvylzX3zNT2GpvBRxGoR4d3sxPRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.53.0.tgz",
+      "integrity": "sha512-MWExpYBGvl+pIvVB/gj/CcWlN2al8AizT7rUbtaYaWNoQkhWARM6W3qpgoCr72CYSN9PborzPmM5MIRe2BrNdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.53.0.tgz",
+      "integrity": "sha512-u4sajgO4nxgmJIgc/y2AqPhkdbOkQH8WugXpA1+pW0ESQhvGZ1oGq61Q4xMbJHJU1hFgtO18QNrcFYDPYH0gwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.53.0.tgz",
+      "integrity": "sha512-Yq9sOZoIOJ5xPjO0qOyHJS4CiPuTkB2en9auxZz7Ar2p5RaC7BzLyVVmAA7zz9/L9YnjjY1DwNxN+ivKXimN/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.53.0.tgz",
+      "integrity": "sha512-es1fVNZEkBqEcQtBpn19SYFgZF7FawlkCjkT/iImfEAus4gun8fBwB1E9hpV5LcR9B0DBNvRIXhW8BQk3JaE+Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.53.0.tgz",
+      "integrity": "sha512-QFmJs2bEu9AO4O6qsmEaZNGi6dFq8N+rT8EHAAnZIq/B9SeJDUbc4DzVxQ48MfDsL7D3sCZzo37zuTuspcURgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4886,6 +5229,68 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/oxfmt": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.53.0.tgz",
+      "integrity": "sha512-9cB5glS3Ip6NMuZ+6NYTao9FCWkDhRtPYCtR3QBu/NxHoFbgzzTvi41N4jxz/GqGfuLKspui1qb/LlSu2IbMcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.53.0",
+        "@oxfmt/binding-android-arm64": "0.53.0",
+        "@oxfmt/binding-darwin-arm64": "0.53.0",
+        "@oxfmt/binding-darwin-x64": "0.53.0",
+        "@oxfmt/binding-freebsd-x64": "0.53.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.53.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.53.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.53.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.53.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.53.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.53.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.53.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.53.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.53.0",
+        "@oxfmt/binding-linux-x64-musl": "0.53.0",
+        "@oxfmt/binding-openharmony-arm64": "0.53.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.53.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.53.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.53.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxfmt/node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -5386,21 +5791,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,15 @@
 {
   "private": true,
+  "license": "MIT",
+  "author": "mizdra",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mizdra/happy-css-modules.git"
+  },
+  "workspaces": [
+    "packages/happy-css-modules",
+    "packages/example"
+  ],
   "type": "module",
   "scripts": {
     "dev:happy-css-modules": "npm -w example run hcm",
@@ -10,20 +20,6 @@
     "lint:tsc": "tsc -p tsconfig.json",
     "test": "vitest run"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/mizdra/happy-css-modules.git"
-  },
-  "author": "mizdra",
-  "license": "MIT",
-  "engines": {
-    "node": "^22.20.0 || ^24.8.0 || >=26.0.0"
-  },
-  "packageManager": "npm@11.16.0",
-  "workspaces": [
-    "packages/happy-css-modules",
-    "packages/example"
-  ],
   "devDependencies": {
     "@eslint/eslintrc": "^3.0.0",
     "@eslint/js": "^8.37.0",
@@ -47,5 +43,9 @@
     "sass": "^1.77.1",
     "typescript": "^5.4.5",
     "vitest": "^2.1.4"
-  }
+  },
+  "engines": {
+    "node": "^22.20.0 || ^24.8.0 || >=26.0.0"
+  },
+  "packageManager": "npm@11.16.0"
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev:happy-css-modules": "npm -w example run hcm",
     "build": "npm run build --workspaces --if-present",
     "lint": "run-s -c lint:*",
-    "lint:prettier": "prettier --check .",
+    "lint:oxfmt": "oxfmt --check",
     "lint:eslint": "ESLINT_USE_FLAT_CONFIG=true eslint .",
     "lint:tsc": "tsc -p tsconfig.json",
     "test": "vitest run"
@@ -20,7 +20,6 @@
     "node": "^22.20.0 || ^24.8.0 || >=26.0.0"
   },
   "packageManager": "npm@11.16.0",
-  "prettier": "@mizdra/prettier-config-mizdra",
   "workspaces": [
     "packages/happy-css-modules",
     "packages/example"
@@ -29,7 +28,7 @@
     "@eslint/eslintrc": "^3.0.0",
     "@eslint/js": "^8.37.0",
     "@mizdra/eslint-config-mizdra": "^2.0.0",
-    "@mizdra/prettier-config-mizdra": "^1.0.0",
+    "@mizdra/oxfmt-config": "^0.2.0",
     "@types/dedent": "^0.7.2",
     "@types/eslint": "^9.6.0",
     "@types/glob": "^8.1.0",
@@ -42,9 +41,9 @@
     "eslint": "^8.57.0",
     "less": "^4.2.0",
     "npm-run-all2": "^6.2.0",
+    "oxfmt": "^0.53.0",
     "postcss-import": "^16.1.0",
     "postcss-simple-vars": "^7.0.1",
-    "prettier": "~2.8.8",
     "sass": "^1.77.1",
     "typescript": "^5.4.5",
     "vitest": "^2.1.4"

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -2,13 +2,13 @@
   "name": "example",
   "version": "1.0.0",
   "description": "",
+  "license": "MIT",
+  "author": "mizdra",
   "type": "commonjs",
   "main": "app.js",
   "scripts": {
     "hcm": "hcm --watch '*-*/*.{css,scss,less}'"
   },
-  "author": "mizdra",
-  "license": "MIT",
   "dependencies": {
     "happy-css-modules": "../happy-css-modules"
   },

--- a/packages/happy-css-modules/package.json
+++ b/packages/happy-css-modules/package.json
@@ -2,33 +2,30 @@
   "name": "happy-css-modules",
   "version": "4.0.0",
   "description": "Creates .d.ts files from CSS Modules .css files",
-  "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc -p tsconfig.build.json"
-  },
-  "bin": {
-    "hcm": "bin/hcm.js"
-  },
+  "keywords": [
+    "css-modules",
+    "typescript"
+  ],
+  "license": "MIT",
+  "author": "mizdra",
   "repository": {
     "type": "git",
     "url": "https://github.com/mizdra/happy-css-modules.git",
     "directory": "packages/happy-css-modules"
   },
-  "keywords": [
-    "css-modules",
-    "typescript"
-  ],
+  "bin": {
+    "hcm": "bin/hcm.js"
+  },
   "files": [
     "bin",
     "src",
     "dist"
   ],
-  "author": "mizdra",
-  "license": "MIT",
-  "engines": {
-    "node": ">=18.0.0"
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json"
   },
   "dependencies": {
     "@file-cache/core": "^2.0.0",
@@ -61,5 +58,8 @@
     "less": {
       "optional": true
     }
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/packages/happy-css-modules/src/emitter/dts.ts
+++ b/packages/happy-css-modules/src/emitter/dts.ts
@@ -107,29 +107,29 @@ function generateTokenDeclarations(
             ': string }>',
           ])
         : typeof token.importedName === 'string'
-        ? new SourceNode(null, null, null, [
-            `& Readonly<{ `,
-            new SourceNode(
-              originalLocation.start.line,
-              // The SourceNode's column is 0-based, but the originalLocation's column is 1-based.
-              originalLocation.start.column - 1,
-              getRelativePath(sourceMapFilePath, originalLocation.filePath),
+          ? new SourceNode(null, null, null, [
+              `& Readonly<{ `,
+              new SourceNode(
+                originalLocation.start.line,
+                // The SourceNode's column is 0-based, but the originalLocation's column is 1-based.
+                originalLocation.start.column - 1,
+                getRelativePath(sourceMapFilePath, originalLocation.filePath),
+                `"${token.name}"`,
+                token.name,
+              ),
+              `: (typeof import(`,
+              `"${getRelativePath(filePath, originalLocation.filePath)}"`,
+              `))["default"]["${token.importedName}"] }>`,
+            ])
+          : // Imported tokens in non-external files are typed by dynamic import.
+            // See https://github.com/mizdra/happy-css-modules/issues/106.
+            new SourceNode(null, null, null, [
+              '& Readonly<Pick<(typeof import(',
+              `"${getRelativePath(filePath, originalLocation.filePath)}"`,
+              '))["default"], ',
               `"${token.name}"`,
-              token.name,
-            ),
-            `: (typeof import(`,
-            `"${getRelativePath(filePath, originalLocation.filePath)}"`,
-            `))["default"]["${token.importedName}"] }>`,
-          ])
-        : // Imported tokens in non-external files are typed by dynamic import.
-          // See https://github.com/mizdra/happy-css-modules/issues/106.
-          new SourceNode(null, null, null, [
-            '& Readonly<Pick<(typeof import(',
-            `"${getRelativePath(filePath, originalLocation.filePath)}"`,
-            '))["default"], ',
-            `"${token.name}"`,
-            '>>',
-          ]),
+              '>>',
+            ]),
     );
   }
   return result;


### PR DESCRIPTION
## Purpose

Migrate the formatter from Prettier to oxfmt, using `@mizdra/oxfmt-config` as the shared config.

## Changes

Split into two commits:

1. **Remove Prettier and introduce oxfmt**
2. **Format all files with oxfmt**

## Verification

- `npm run lint:oxfmt` passes (85 files)
- `npm run lint:tsc` passes (checked because import sorting reordered imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)