### PR TITLE
chore: preinstall less v3/v4 and switch via LESS_VERSION env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
 
       - run: npm run test
         env:
-          CI: true
           LESS_VERSION: ${{ matrix.less }}
 
   verify-if-example-is-outdated:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
           - node: '22'
           - node: '24'
           - node: '26'
-          # less
+          # less v3
           - node: '26'
-            less: '^3.0.0'
+            less: '3'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -39,12 +39,10 @@ jobs:
           cache: 'npm'
       - run: npm install
 
-      - run: npm i -D less@${{ matrix.less }}
-        if: ${{ matrix.less }}
-
       - run: npm run test
         env:
           CI: true
+          LESS_VERSION: ${{ matrix.less }}
 
   verify-if-example-is-outdated:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,8 @@
         "@typescript/server-harness": "^0.3.5",
         "dedent": "^1.5.3",
         "less": "^4.2.0",
+        "less-3": "npm:less@^3.0.0",
+        "less-4": "npm:less@^4.2.0",
         "npm-run-all2": "^6.2.0",
         "oxfmt": "^0.53.0",
         "oxlint": "^1.68.0",
@@ -2519,38 +2521,116 @@
         "source-map": "~0.6.0"
       }
     },
-    "node_modules/less/node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+    "node_modules/less-3": {
+      "name": "less",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/less/-/less-3.13.1.tgz",
+      "integrity": "sha512-SwA1aQXGUvp+P5XdZslUOhhLnClSLIjWvJhmd+Vgib5BFIr9lMNlQwmwUNOjXThF/A0x+MCYYPeWEfeWiLRnTw==",
       "dev": true,
-      "optional": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
+        "copy-anything": "^2.0.1",
+        "tslib": "^1.10.0"
+      },
+      "bin": {
+        "lessc": "bin/lessc"
       },
       "engines": {
         "node": ">=6"
+      },
+      "optionalDependencies": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "make-dir": "^2.1.0",
+        "mime": "^1.4.1",
+        "native-request": "^1.0.5",
+        "source-map": "~0.6.0"
       }
     },
-    "node_modules/less/node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+    "node_modules/less-3/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=0.10.0"
       }
     },
-    "node_modules/less/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+    "node_modules/less-3/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
-      "optional": true,
+      "license": "0BSD"
+    },
+    "node_modules/less-4": {
+      "name": "less",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.6.4.tgz",
+      "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "copy-anything": "^3.0.5",
+        "parse-node-version": "^1.0.1"
+      },
       "bin": {
-        "semver": "bin/semver"
+        "lessc": "bin/lessc"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "errno": "^0.1.1",
+        "graceful-fs": "^4.1.2",
+        "image-size": "~0.5.0",
+        "make-dir": "^2.1.0",
+        "mime": "^1.4.1",
+        "needle": "^3.1.0",
+        "source-map": "~0.6.0"
+      }
+    },
+    "node_modules/less-4/node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/less-4/node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/less-4/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/less/node_modules/source-map": {
@@ -2614,6 +2694,32 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/memorystream": {
@@ -2684,6 +2790,14 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/native-request": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/native-request/-/native-request-1.1.2.tgz",
+      "integrity": "sha512-/etjwrK0J4Ebbcnt35VMWnfiUX/B04uwGJxyJInagxDqf2z5drSt/lsOvEMWGYunz1kaLZAFrV4NDAbOoDKvAQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/needle": {
       "version": "3.2.0",
@@ -3428,6 +3542,17 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "@typescript/server-harness": "^0.3.5",
     "dedent": "^1.5.3",
     "less": "^4.2.0",
+    "less-3": "npm:less@^3.0.0",
+    "less-4": "npm:less@^4.2.0",
     "npm-run-all2": "^6.2.0",
     "oxfmt": "^0.53.0",
     "oxlint": "^1.68.0",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // oxlint-disable-next-line unicorn/no-useless-spread
+      ...(process.env['LESS_VERSION'] ? { less: `less-${process.env['LESS_VERSION']}` } : {}),
+    },
+  },
   test: {
     include: ['src/**/*.test.ts?(x)'],
     globals: true,


### PR DESCRIPTION
## Motivation

Previously, CI dynamically installed `less@^3.0.0` at runtime via `npm i -D less@...`. This exposes an attack surface for supply chain attacks, so we switch to pre-installing v3/v4 in devDependencies and locking them completely via package-lock.json.

## Changes

- Add `less-3` / `less-4` as npm aliases in devDependencies to avoid dynamic installation in CI
- Add `resolve.alias` to `vitest.config.mts` to switch the less version via the `LESS_VERSION` env var
- Remove the `npm i -D less@...` step from `.github/workflows/ci.yml` and switch via the `less` matrix variable and `LESS_VERSION` env var

## Test plan

- [ ] Tests pass with `LESS_VERSION=3 npm run test`
- [ ] Tests pass with `LESS_VERSION=4 npm run test`
- [ ] All CI matrix jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)