### PR TITLE
chore: upgrade TypeScript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "postcss-import": "^16.1.0",
         "postcss-simple-vars": "^7.0.1",
         "sass": "^1.77.1",
-        "typescript": "^5.4.5",
+        "typescript": "^6.0.3",
         "vitest": "^2.1.4"
       },
       "engines": {
@@ -3701,10 +3701,11 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "postcss-import": "^16.1.0",
     "postcss-simple-vars": "^7.0.1",
     "sass": "^1.77.1",
-    "typescript": "^5.4.5",
+    "typescript": "^6.0.3",
     "vitest": "^2.1.4"
   },
   "peerDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,6 @@
     "noEmit": true,
 
     // Vitest global types
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   }
 }


### PR DESCRIPTION
## Summary

- Upgrade TypeScript from `^5.4.5` to `^6.0.3`
- Explicitly add `node` to `types` in `tsconfig.json`

## Motivation

This is a preparatory step toward migrating to [tsgo](https://github.com/microsoft/typescript-go).

tsgo has several incompatibilities with TypeScript v5, making a direct migration difficult. TypeScript v6, on the other hand, has been aligned with tsgo through various spec changes to ensure compatibility. By upgrading to v6 first, the eventual migration to tsgo becomes much easier.

## Testing

- `tsc --noEmit` passes with no errors
- All tests pass (`npm test`)