### PR TITLE
chore!: replace `yargs` with node:util's `parseArgs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,33 +54,36 @@ If you want to customize the behavior, see `--help`.
 $ hcm --help
 Generate .d.ts and .d.ts.map for CSS modules.
 
-hcm [options] <glob>
+Usage: hcm [options] <glob>
 
 Options:
-  -w, --watch                Watch input directory's css files or pattern                                         [boolean] [default: false]
-      --localsConvention     Style of exported class names.                  [choices: "camelCase", "camelCaseOnly", "dashes", "dashesOnly"]
-      --declarationMap       Create sourcemaps for d.ts files                                                      [boolean] [default: true]
-      --sassLoadPaths        The option compatible with sass's `--load-path`.                                                        [array]
-      --lessIncludePaths     The option compatible with less's `--include-path`.                                                     [array]
-      --webpackResolveAlias  The option compatible with webpack's `resolve.alias`.                                                  [string]
-      --postcssConfig        The option compatible with postcss's `--config`.                                                       [string]
-      --arbitraryExtensions  Generate `.d.css.ts` instead of `.css.d.ts`.                                          [boolean] [default: true]
-      --cache                Only generate .d.ts and .d.ts.map for changed files.                                  [boolean] [default: true]
-      --cacheStrategy        Strategy for the cache to use for detecting changed files.[choices: "content", "metadata"] [default: "content"]
-      --logLevel             What level of logs to report.                            [choices: "debug", "info", "silent"] [default: "info"]
-  -o, --outDir               Output directory for generated files.                                                                  [string]
-  -h, --help                 Show help                                                                                             [boolean]
-  -v, --version              Show version number                                                                                   [boolean]
+  -w, --[no-]watch               Watch input directory's css files or pattern (default: false)
+      --localsConvention         Style of exported class names.
+                                 [choices: camelCase, camelCaseOnly, dashes, dashesOnly]
+      --[no-]declarationMap      Create sourcemaps for d.ts files (default: true)
+      --sassLoadPaths            The option compatible with sass's `--load-path`.
+      --lessIncludePaths         The option compatible with less's `--include-path`.
+      --webpackResolveAlias      The option compatible with webpack's `resolve.alias`.
+      --postcssConfig            The option compatible with postcss's `--config`.
+      --[no-]arbitraryExtensions Generate `.d.css.ts` instead of `.css.d.ts` (default: false)
+      --[no-]cache               Only generate .d.ts and .d.ts.map for changed files (default: true)
+      --cacheStrategy            Strategy for the cache to use for detecting changed files.
+                                 [choices: content, metadata] (default: content)
+      --logLevel                 What level of logs to report.
+                                 [choices: debug, info, silent] (default: info)
+  -o, --outDir                   Output directory for generated files.
+  -h, --help                     Show help
+  -v, --version                  Show version number
 
 Examples:
-  hcm 'src/**/*.module.css'                                       Generate .d.ts and .d.ts.map.
-  hcm 'src/**/*.module.{css,scss,less}'                           Also generate files for sass and less.
-  hcm 'src/**/*.module.css' --watch                               Watch for changes and generate .d.ts and .d.ts.map.
-  hcm 'src/**/*.module.css' --declarationMap=false                Generate .d.ts only.
-  hcm 'src/**/*.module.css' --sassLoadPaths=src/style             Run with sass's `--load-path`.
-  hcm 'src/**/*.module.css' --lessIncludePaths=src/style          Run with less's `--include-path`.
-  hcm 'src/**/*.module.css' --webpackResolveAlias='{"@": "src"}'  Run with webpack's `resolve.alias`.
-  hcm 'src/**/*.module.css' --cache=false                         Disable cache.
+  hcm 'src/**/*.module.css'
+  hcm 'src/**/*.module.{css,scss,less}'
+  hcm 'src/**/*.module.css' --watch
+  hcm 'src/**/*.module.css' --no-declarationMap
+  hcm 'src/**/*.module.css' --sassLoadPaths src/style
+  hcm 'src/**/*.module.css' --lessIncludePaths src/style
+  hcm 'src/**/*.module.css' --webpackResolveAlias '{"@": "src"}'
+  hcm 'src/**/*.module.css' --no-cache
 ```
 
 ## How docs definition jumps work?

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,7 @@
         "postcss-modules": "^6.0.0",
         "postcss-selector-parser": "^6.0.16",
         "postcss-value-parser": "^4.2.0",
-        "source-map": "^0.7.4",
-        "yargs": "^17.7.2"
+        "source-map": "^0.7.4"
       },
       "bin": {
         "hcm": "bin/hcm.js"
@@ -33,7 +32,6 @@
         "@types/dedent": "^0.7.2",
         "@types/less": "^3.0.6",
         "@types/node": "^22.19.19",
-        "@types/yargs": "^17.0.32",
         "@typescript/server-harness": "^0.3.5",
         "dedent": "^1.5.3",
         "less": "^4.2.0",
@@ -1584,21 +1582,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
-      "dev": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
-      "dev": true
-    },
     "node_modules/@typescript/server-harness": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@typescript/server-harness/-/server-harness-0.3.5.tgz",
@@ -1716,14 +1699,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/anymatch": {
@@ -1855,19 +1830,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -1952,11 +1914,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
     "node_modules/enhanced-resolve": {
       "version": "5.16.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
@@ -2019,14 +1976,6 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/estree-walker": {
@@ -2103,14 +2052,6 @@
       "integrity": "sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==",
       "dependencies": {
         "loader-utils": "^3.2.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob-parent": {
@@ -2220,14 +2161,6 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3163,14 +3096,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -3339,30 +3264,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
       "integrity": "sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A=="
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -3650,60 +3551,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yaml": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
@@ -3713,31 +3560,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "engines": {
-        "node": ">=12"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "update-example": "cd example && node ../bin/hcm.js '*-*/*.{css,scss,less}' --cache=false",
+    "update-example": "cd example && node ../bin/hcm.js '*-*/*.{css,scss,less}' --no-cache",
     "dev": "npm run update-example -- --watch",
     "build": "tsc -p tsconfig.build.json",
     "lint": "run-s -c lint:*",
@@ -45,8 +45,7 @@
     "postcss-modules": "^6.0.0",
     "postcss-selector-parser": "^6.0.16",
     "postcss-value-parser": "^4.2.0",
-    "source-map": "^0.7.4",
-    "yargs": "^17.7.2"
+    "source-map": "^0.7.4"
   },
   "devDependencies": {
     "@mizdra/oxfmt-config": "^0.2.0",
@@ -54,7 +53,6 @@
     "@types/dedent": "^0.7.2",
     "@types/less": "^3.0.6",
     "@types/node": "^22.19.19",
-    "@types/yargs": "^17.0.32",
     "@typescript/server-harness": "^0.3.5",
     "dedent": "^1.5.3",
     "less": "^4.2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,126 +1,128 @@
-import yargs from 'yargs';
-import { hideBin } from 'yargs/helpers';
+import { parseArgs } from 'node:util';
 import { DEFAULT_ARBITRARY_EXTENSIONS } from './config.js';
 import { type RunnerOptions } from './runner.js';
 import { getPackageJson } from './util.js';
 
-/**
- * Parse command line arguments.
- * @returns Runner options.
- */
+const HELP_TEXT = `
+Generate .d.ts and .d.ts.map for CSS modules.
+
+Usage: hcm [options] <glob>
+
+Options:
+  -w, --[no-]watch               Watch input directory's css files or pattern (default: false)
+      --localsConvention         Style of exported class names.
+                                 [choices: camelCase, camelCaseOnly, dashes, dashesOnly]
+      --[no-]declarationMap      Create sourcemaps for d.ts files (default: true)
+      --sassLoadPaths            The option compatible with sass's \`--load-path\`.
+      --lessIncludePaths         The option compatible with less's \`--include-path\`.
+      --webpackResolveAlias      The option compatible with webpack's \`resolve.alias\`.
+      --postcssConfig            The option compatible with postcss's \`--config\`.
+      --[no-]arbitraryExtensions Generate \`.d.css.ts\` instead of \`.css.d.ts\` (default: false)
+      --[no-]cache               Only generate .d.ts and .d.ts.map for changed files (default: true)
+      --cacheStrategy            Strategy for the cache to use for detecting changed files.
+                                 [choices: content, metadata] (default: content)
+      --logLevel                 What level of logs to report.
+                                 [choices: debug, info, silent] (default: info)
+  -o, --outDir                   Output directory for generated files.
+  -h, --help                     Show help
+  -v, --version                  Show version number
+
+Examples:
+  hcm 'src/**/*.module.css'
+  hcm 'src/**/*.module.{css,scss,less}'
+  hcm 'src/**/*.module.css' --watch
+  hcm 'src/**/*.module.css' --no-declarationMap
+  hcm 'src/**/*.module.css' --sassLoadPaths src/style
+  hcm 'src/**/*.module.css' --lessIncludePaths src/style
+  hcm 'src/**/*.module.css' --webpackResolveAlias '{"@": "src"}'
+  hcm 'src/**/*.module.css' --no-cache
+`.trim();
+
 export function parseArgv(argv: string[]): RunnerOptions {
   const pkgJson = getPackageJson();
-  const parsedArgv = yargs(hideBin(argv))
-    .wrap(Math.min(140, process.stdout.columns))
-    .scriptName('hcm')
-    .usage('Generate .d.ts and .d.ts.map for CSS modules.\n\n$0 [options] <glob>')
-    .example("$0 'src/**/*.module.css'", 'Generate .d.ts and .d.ts.map.')
-    .example("$0 'src/**/*.module.{css,scss,less}'", 'Also generate files for sass and less.')
-    .example("$0 'src/**/*.module.css' --watch", 'Watch for changes and generate .d.ts and .d.ts.map.')
-    .example("$0 'src/**/*.module.css' --declarationMap=false", 'Generate .d.ts only.')
-    .example("$0 'src/**/*.module.css' --sassLoadPaths=src/style", "Run with sass's `--load-path`.")
-    .example("$0 'src/**/*.module.css' --lessIncludePaths=src/style", "Run with less's `--include-path`.")
-    .example('$0 \'src/**/*.module.css\' --webpackResolveAlias=\'{"@": "src"}\'', "Run with webpack's `resolve.alias`.")
-    .example("$0 'src/**/*.module.css' --cache=false", 'Disable cache.')
-    .detectLocale(false)
-    .option('watch', {
-      type: 'boolean',
-      alias: 'w',
-      default: false,
-      describe: "Watch input directory's css files or pattern",
-    })
-    .option('localsConvention', {
-      choices: ['camelCase', 'camelCaseOnly', 'dashes', 'dashesOnly'] as const,
-      describe: 'Style of exported class names.',
-    })
-    .option('declarationMap', {
-      type: 'boolean',
-      default: true,
-      describe: 'Create sourcemaps for d.ts files',
-    })
-    .option('sassLoadPaths', {
-      array: true,
-      nargs: 1,
-      describe: "The option compatible with sass's `--load-path`.",
-    })
-    .option('lessIncludePaths', {
-      array: true,
-      nargs: 1,
-      describe: "The option compatible with less's `--include-path`.",
-    })
-    .option('webpackResolveAlias', {
-      string: true,
-      describe: "The option compatible with webpack's `resolve.alias`.",
-    })
-    // TODO: Support --noPostcssConfig option.
-    .option('postcssConfig', {
-      string: true,
-      describe: "The option compatible with postcss's `--config`.",
-    })
-    .option('arbitraryExtensions', {
-      type: 'boolean',
-      default: DEFAULT_ARBITRARY_EXTENSIONS,
-      describe: 'Generate `.d.css.ts` instead of `.css.d.ts`.',
-    })
-    .option('cache', {
-      type: 'boolean',
-      default: true,
-      describe: 'Only generate .d.ts and .d.ts.map for changed files.',
-    })
-    .option('cacheStrategy', {
-      choices: ['content', 'metadata'] as const,
-      // NOTE: This is a workaround for `parsedArgv.cacheStrategy` type breaks.
-      default: 'content' as RunnerOptions['cacheStrategy'],
-      describe: 'Strategy for the cache to use for detecting changed files.',
-    })
-    .option('logLevel', {
-      choices: ['debug', 'info', 'silent'] as const,
-      default: 'info' as RunnerOptions['logLevel'],
-      describe: 'What level of logs to report.',
-    })
-    .option('outDir', {
-      type: 'string',
-      alias: 'o',
-      describe: 'Output directory for generated files.',
-    })
-    .alias('h', 'help')
-    .alias('v', 'version')
-    .version(pkgJson.version)
-    .check((argv) => {
-      const patterns = argv._;
-      // TODO: support multiple patterns
-      if (patterns.length !== 1) throw new Error('Only one pattern is allowed.');
-      if (argv.webpackResolveAlias) {
-        let parsedWebpackResolveAlias: unknown;
-        try {
-          parsedWebpackResolveAlias = JSON.parse(argv.webpackResolveAlias);
-        } catch {
-          throw new Error('--webpackResolveAlias must be a valid JSON string.');
-        }
-        if (typeof parsedWebpackResolveAlias !== 'object' || parsedWebpackResolveAlias === null)
-          throw new Error('--webpackResolveAlias must be an object');
-        if (!Object.keys(parsedWebpackResolveAlias).every((key) => typeof key === 'string'))
-          throw new Error('--webpackResolveAlias must be an object of string keys');
-        if (!Object.values(parsedWebpackResolveAlias).every((value) => typeof value === 'string'))
-          throw new Error('--webpackResolveAlias must be an object of string values');
-      }
-      return true;
-    })
-    .parseSync();
-  const patterns: string[] = parsedArgv._.map((pattern) => pattern.toString());
+
+  const { values, positionals } = parseArgs({
+    args: argv.slice(2),
+    options: {
+      watch: { type: 'boolean', short: 'w', default: false },
+      localsConvention: { type: 'string' },
+      declarationMap: { type: 'boolean', default: true },
+      sassLoadPaths: { type: 'string', multiple: true },
+      lessIncludePaths: { type: 'string', multiple: true },
+      webpackResolveAlias: { type: 'string' },
+      postcssConfig: { type: 'string' },
+      arbitraryExtensions: { type: 'boolean', default: DEFAULT_ARBITRARY_EXTENSIONS },
+      cache: { type: 'boolean', default: true },
+      cacheStrategy: { type: 'string', default: 'content' },
+      logLevel: { type: 'string', default: 'info' },
+      outDir: { type: 'string', short: 'o' },
+      help: { type: 'boolean', short: 'h' },
+      version: { type: 'boolean', short: 'v' },
+    },
+    allowPositionals: true,
+    allowNegative: true,
+  });
+
+  if (values.help) {
+    // oxlint-disable-next-line no-console
+    console.log(HELP_TEXT);
+    // oxlint-disable-next-line unicorn/no-process-exit
+    process.exit(0);
+  }
+
+  if (values.version) {
+    // oxlint-disable-next-line no-console
+    console.log(pkgJson.version);
+    // oxlint-disable-next-line unicorn/no-process-exit
+    process.exit(0);
+  }
+
+  if (positionals.length !== 1) throw new Error('Only one pattern is allowed.');
+
+  const validLocalsConventions = ['camelCase', 'camelCaseOnly', 'dashes', 'dashesOnly'];
+  if (values.localsConvention !== undefined && !validLocalsConventions.includes(values.localsConvention)) {
+    throw new Error(`--localsConvention must be one of: ${validLocalsConventions.join(', ')}`);
+  }
+
+  const validCacheStrategies = ['content', 'metadata'];
+  if (!validCacheStrategies.includes(values.cacheStrategy)) {
+    throw new Error(`--cacheStrategy must be one of: ${validCacheStrategies.join(', ')}`);
+  }
+
+  const validLogLevels = ['debug', 'info', 'silent'];
+  if (!validLogLevels.includes(values.logLevel)) {
+    throw new Error(`--logLevel must be one of: ${validLogLevels.join(', ')}`);
+  }
+
+  let webpackResolveAlias: Record<string, string> | undefined;
+  if (values.webpackResolveAlias) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(values.webpackResolveAlias);
+    } catch {
+      throw new Error('--webpackResolveAlias must be a valid JSON string.');
+    }
+    if (typeof parsed !== 'object' || parsed === null) throw new Error('--webpackResolveAlias must be an object');
+    if (!Object.keys(parsed).every((key) => typeof key === 'string'))
+      throw new Error('--webpackResolveAlias must be an object of string keys');
+    if (!Object.values(parsed).every((value) => typeof value === 'string'))
+      throw new Error('--webpackResolveAlias must be an object of string values');
+    webpackResolveAlias = parsed as Record<string, string>;
+  }
+
   return {
-    pattern: patterns[0]!,
-    watch: parsedArgv.watch,
-    localsConvention: parsedArgv.localsConvention,
-    declarationMap: parsedArgv.declarationMap,
-    sassLoadPaths: parsedArgv.sassLoadPaths?.map((item) => item.toString()),
-    lessIncludePaths: parsedArgv.lessIncludePaths?.map((item) => item.toString()),
-    webpackResolveAlias: parsedArgv.webpackResolveAlias ? JSON.parse(parsedArgv.webpackResolveAlias) : undefined,
-    postcssConfig: parsedArgv.postcssConfig,
-    arbitraryExtensions: parsedArgv.arbitraryExtensions,
-    cache: parsedArgv.cache,
-    cacheStrategy: parsedArgv.cacheStrategy,
-    logLevel: parsedArgv.logLevel,
-    outDir: parsedArgv.outDir,
+    pattern: positionals[0]!,
+    watch: values.watch,
+    localsConvention: values.localsConvention as RunnerOptions['localsConvention'],
+    declarationMap: values.declarationMap,
+    sassLoadPaths: values.sassLoadPaths,
+    lessIncludePaths: values.lessIncludePaths,
+    webpackResolveAlias,
+    postcssConfig: values.postcssConfig,
+    arbitraryExtensions: values.arbitraryExtensions,
+    cache: values.cache,
+    cacheStrategy: values.cacheStrategy as RunnerOptions['cacheStrategy'],
+    logLevel: values.logLevel as RunnerOptions['logLevel'],
+    outDir: values.outDir,
   };
 }


### PR DESCRIPTION
## Summary

- Replace `yargs` (+ `@types/yargs`) with Node.js built-in `util.parseArgs` to reduce supply chain attack risk
- 18 packages removed from `node_modules`
- Help text is now defined as a static string; `--help`/`--version` are handled manually

## Breaking Changes

Boolean options no longer accept the `--option=true` / `--option=false` syntax (e.g. `--cache=false`). Use `--option` / `--no-option` instead.

| Before | After |
|---|---|
| `--cache=false` | `--no-cache` |
| `--cache=true` | `--cache` |
| `--watch=false` | `--no-watch` |
| `--declarationMap=false` | `--no-declarationMap` |
| `--arbitraryExtensions=false` | `--no-arbitraryExtensions` |

## Test plan

- [x] `npm test src/cli.test.ts` passes
- [x] `hcm --help` prints the help text
- [x] `hcm --version` prints the version