### PR TITLE
test: suppress false-positive source map warning from Vite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "postcss-simple-vars": "^7.0.1",
         "sass": "^1.77.1",
         "typescript": "^6.0.3",
+        "vite": "^8.0.16",
         "vitest": "^4.1.8"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "postcss-simple-vars": "^7.0.1",
     "sass": "^1.77.1",
     "typescript": "^6.0.3",
+    "vite": "^8.0.16",
     "vitest": "^4.1.8"
   },
   "peerDependencies": {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,6 +1,27 @@
+import type { Plugin } from 'vite';
 import { defineConfig } from 'vitest/config';
 
+// Some tests have snapshots containing a `//# sourceMappingURL=*.css.d.ts.map` magic comment.
+// Vite misinterprets it as a real source map reference and warns that it cannot read the
+// (non-existent) map file. Suppress this false-positive warning.
+//
+// `customLogger` option cannot be used because Vitest overwrites it internally, so wrap the resolved
+// logger in `configResolved` instead.
+const suppressSourceMapWarning: Plugin = {
+  name: 'suppress-source-map-warning',
+  configResolved(config) {
+    const originalWarn = config.logger.warn.bind(config.logger);
+    config.logger.warn = (msg, options) => {
+      if (msg.includes('Failed to load source map') && msg.includes('.css.d.ts.map')) {
+        return;
+      }
+      originalWarn(msg, options);
+    };
+  },
+};
+
 export default defineConfig({
+  plugins: [suppressSourceMapWarning],
   resolve: {
     alias: {
       // oxlint-disable-next-line unicorn/no-useless-spread


### PR DESCRIPTION
## What

Vite's `extractSourcemapFromFile` misinterprets the `//# sourceMappingURL=*.css.d.ts.map` magic comment inside test snapshots as a real source map reference, and warns that it cannot read the (non-existent) map file during `npm test`.

This adds a Vite plugin that wraps the resolved `logger.warn` in `configResolved` to suppress only this false-positive warning.

## How to test

```
npm test src/runner.test.ts
```

Confirm no `Failed to load source map` warning appears in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)