### PR TITLE
deps: replace import-meta-resolve with import.meta.resolve

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "camelcase": "^8.0.0",
         "chokidar": "^3.6.0",
         "enhanced-resolve": "^5.16.1",
-        "import-meta-resolve": "^4.1.0",
         "postcss": "^8.4.38",
         "postcss-load-config": "^5.1.0",
         "postcss-modules": "^6.0.0",
@@ -1792,15 +1791,6 @@
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
       "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
       "dev": true
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "camelcase": "^8.0.0",
     "chokidar": "^3.6.0",
     "enhanced-resolve": "^5.16.1",
-    "import-meta-resolve": "^4.1.0",
     "postcss": "^8.4.38",
     "postcss-load-config": "^5.1.0",
     "postcss-modules": "^6.0.0",

--- a/src/resolver/node-resolver.ts
+++ b/src/resolver/node-resolver.ts
@@ -1,7 +1,6 @@
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import { resolve } from 'import-meta-resolve';
 import type { Resolver } from './index.js';
 
 export const createNodeResolver: () => Resolver = () => (specifier, options) => {
-  return fileURLToPath(resolve(specifier, pathToFileURL(options.request).href));
+  return fileURLToPath(import.meta.resolve(specifier, pathToFileURL(options.request).href));
 };

--- a/src/test-util/tsserver.ts
+++ b/src/test-util/tsserver.ts
@@ -3,7 +3,6 @@ import { mkdir, writeFile as nativeWriteFile, glob } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import serverHarness from '@typescript/server-harness';
-import { resolve } from 'import-meta-resolve';
 import type { server } from 'typescript/lib/tsserverlibrary.js';
 import { getIndexFromLineColumn } from './line-column.js';
 import { getFixturePath } from './util.js';
@@ -35,7 +34,7 @@ type Definition = {
 };
 
 export function createTSServer() {
-  const server = serverHarness.launchServer(fileURLToPath(resolve('typescript/lib/tsserver.js', import.meta.url)), [
+  const server = serverHarness.launchServer(fileURLToPath(import.meta.resolve('typescript/lib/tsserver.js')), [
     // ATA generates some extra network traffic and isn't usually relevant when profiling
     '--disableAutomaticTypingAcquisition',
   ]);

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,6 @@ import { constants, readFileSync } from 'node:fs';
 import { access } from 'node:fs/promises';
 import { join, dirname, resolve, matchesGlob } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolve as importMetaResolve } from 'import-meta-resolve';
 
 /**
  * The SystemError type of Node.js.
@@ -76,7 +75,7 @@ export function getInstalledPeerDependencies(): string[] {
   const result = [];
   for (const deps of Object.keys(pkgJson.peerDependencies)) {
     try {
-      importMetaResolve(deps, import.meta.url);
+      import.meta.resolve(deps);
       // If the package is installed, push it to the result array.
       result.push(deps);
     } catch {


### PR DESCRIPTION
Remove the import-meta-resolve package and replace all usages with the Node.js built-in import.meta.resolve(). Since the engines field requires Node.js v22.20+ where this API is always available, the package is redundant. This reduces supply chain attack surface by eliminating one dependency.