### PR TITLE
deps: update postcss-load-config to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "enhanced-resolve": "^5.22.2",
         "import-meta-resolve": "^4.2.0",
         "postcss": "^8.5.15",
-        "postcss-load-config": "^5.1.0",
+        "postcss-load-config": "^6.0.1",
         "postcss-modules": "^6.0.1",
         "postcss-selector-parser": "^7.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -3251,9 +3251,9 @@
       }
     },
     "node_modules/postcss-load-config": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-5.1.0.tgz",
-      "integrity": "sha512-G5AJ+IX0aD0dygOE0yFZQ/huFFMSNneyfp0e3/bT05a8OfPC5FUoZRPfGijUdGOJNMewJiwzcHJXFafFzeKFVA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
       "funding": [
         {
           "type": "opencollective",
@@ -3264,9 +3264,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "lilconfig": "^3.1.1",
-        "yaml": "^2.4.2"
+        "lilconfig": "^3.1.1"
       },
       "engines": {
         "node": ">= 18"
@@ -3274,7 +3274,8 @@
       "peerDependencies": {
         "jiti": ">=1.21.0",
         "postcss": ">=8.0.9",
-        "tsx": "^4.8.1"
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
       },
       "peerDependenciesMeta": {
         "jiti": {
@@ -3284,6 +3285,9 @@
           "optional": true
         },
         "tsx": {
+          "optional": true
+        },
+        "yaml": {
           "optional": true
         }
       }
@@ -4011,17 +4015,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.2.tgz",
-      "integrity": "sha512-B3VqDZ+JAg1nZpaEmWtTXUlBneoGx6CPM9b0TENK6aoSu5t73dItudwdgmi6tHlIZZId4dZ9skcAQ2UbcyAeVA==",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "enhanced-resolve": "^5.22.2",
     "import-meta-resolve": "^4.2.0",
     "postcss": "^8.5.15",
-    "postcss-load-config": "^5.1.0",
+    "postcss-load-config": "^6.0.1",
     "postcss-modules": "^6.0.1",
     "postcss-selector-parser": "^7.1.1",
     "postcss-value-parser": "^4.2.0",


### PR DESCRIPTION
## Summary

Update `postcss-load-config` from v5 to v6.

## Breaking Changes

If you use a YAML-based PostCSS config file (`postcss.config.yaml` or `postcss.config.yml`), you must now install the [`yaml`](https://www.npmjs.com/package/yaml) package separately:

```sh
npm install --save-dev yaml
```

This is because `postcss-load-config` v6 no longer bundles `yaml` as a dependency — it is now an optional peer dependency. If `yaml` is not installed, loading a YAML config file will throw an error.

If you use a JavaScript or TypeScript PostCSS config file (e.g. `postcss.config.js`, `postcss.config.ts`), no action is required.

## How to test

```sh
npm test
```
