### PR TITLE
fix: exclude test files from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "files": [
     "bin",
     "src",
+    "!src/**/*.test.ts",
+    "!src/**/__snapshots__",
+    "!src/test-util",
     "dist"
   ],
   "type": "module",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/__snapshots__", "src/test-util"],
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src", // To avoid inadvertently changing the directory structure under dist/.


### PR DESCRIPTION
## Summary

- Add negation patterns to `files` in `package.json` to exclude `*.test.ts`, `__snapshots__`, and `test-util` from the published package
- Add `exclude` to `tsconfig.build.json` to also exclude them from the build output

## How to verify

Run the following and confirm no test-related files are listed:

```
npm pack --dry-run
```