### PR TITLE
fix: fix crash with postcss 8.5.16+ when resolving original token locations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "chokidar": "^5.0.0",
         "enhanced-resolve": "^5.22.2",
         "import-meta-resolve": "^4.2.0",
-        "postcss": "^8.5.15",
+        "postcss": "^8.5.16",
         "postcss-load-config": "^6.0.1",
         "postcss-modules": "^6.0.1",
         "postcss-selector-parser": "^7.1.1",
@@ -3111,9 +3111,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.16",
+      "resolved": "https://npm.flatt.tech/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chokidar": "^5.0.0",
     "enhanced-resolve": "^5.22.2",
     "import-meta-resolve": "^4.2.0",
-    "postcss": "^8.5.15",
+    "postcss": "^8.5.16",
     "postcss-load-config": "^6.0.1",
     "postcss-modules": "^6.0.1",
     "postcss-selector-parser": "^7.1.1",

--- a/src/locator/postcss.ts
+++ b/src/locator/postcss.ts
@@ -103,11 +103,11 @@ export function getOriginalLocationOfClassSelector(rule: Rule, classSelector: Cl
     filePath: classSelectorOrigin.file,
     start: {
       line: classSelectorOrigin.line,
-      column: classSelectorOrigin.column + 1,
+      column: classSelectorOrigin.column,
     },
     end: {
       line: classSelectorOrigin.line,
-      column: classSelectorOrigin.column + classSelector.value.length + 1,
+      column: classSelectorOrigin.column + classSelector.value.length,
     },
   };
 }

--- a/src/locator/postcss.ts
+++ b/src/locator/postcss.ts
@@ -94,9 +94,7 @@ export function getOriginalLocationOfClassSelector(rule: Rule, classSelector: Cl
 
   const classSelectorOrigin = rule.source.input.origin(
     classSelectorLocation.start.line,
-    // The column of `Input#origin` is 0-based. This behavior is undocumented and probably a postcss's bug.
-    // TODO: Open PR to postcss/postcss
-    classSelectorLocation.start.column - 1,
+    classSelectorLocation.start.column,
   );
   if (classSelectorOrigin === false || classSelectorOrigin.file === undefined) {
     return { filePath: undefined, start: undefined, end: undefined };


### PR DESCRIPTION
postcss 8.5.16 (postcss/postcss#2036) fixed `Input#origin()` to correctly accept 1-based columns and internally convert to 0-based before passing to `source-map-js`.

The `- 1` workaround in `getOriginalLocationOfClassSelector` is no longer needed and causes double subtraction, resulting in `column = -1` which crashes `source-map-js`:

```
TypeError: Column must be greater than or equal to 0, got -1
```

Fixes #320